### PR TITLE
PDO Param integer should return integer not string

### DIFF
--- a/src/datasources/PdoDataSource.php
+++ b/src/datasources/PdoDataSource.php
@@ -245,7 +245,7 @@ class PdoDataSource extends DataSource
             case "boolean":
                 return PDO::PARAM_BOOL;
             case "integer":
-                return PDO::PARAM_STR;
+                return PDO::PARAM_INT;
             case "NULL":
                 return PDO::PARAM_NULL;
             case "resource":


### PR DESCRIPTION
Hello, as the commit says, there is no reason about returning STRING when param type is equal to INTEGER.

This MAY be a breaking change though.

Exemple :

I'm running a custom query with some dynamic fields. 
One of these fields is the SQL Limit, but as the type return is string, the query cannot work, MYSQL does not read the LIMIT '10' but reads LIMIT 10.

