### PR TITLE
Fix/simplify uksort callbacks in the src/datasources classes.

### DIFF
--- a/src/datasources/MySQLDataSource.php
+++ b/src/datasources/MySQLDataSource.php
@@ -215,8 +215,7 @@ class MySQLDataSource extends DataSource
         uksort(
             $sqlParams, 
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($sqlParams as $key=>$value) {
@@ -323,8 +322,7 @@ class MySQLDataSource extends DataSource
         uksort(
             $paramNames,
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($paramNames as $k) {

--- a/src/datasources/OracleDataSource.php
+++ b/src/datasources/OracleDataSource.php
@@ -228,8 +228,7 @@ class OracleDataSource extends DataSource
         uksort(
             $sqlParams,
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($sqlParams as $key=>$value) {

--- a/src/datasources/PdoDataSource.php
+++ b/src/datasources/PdoDataSource.php
@@ -213,7 +213,7 @@ class PdoDataSource extends DataSource
         uksort(
             $sqlParams,
             function ($k1, $k2) {
-                return strlen($k1) < strlen($k2);
+                return strlen($k1) - strlen($k2);
             }
         );
         $resultQuery = $query;
@@ -273,7 +273,7 @@ class PdoDataSource extends DataSource
         uksort(
             $sqlParams,
             function ($k1, $k2) {
-                return strlen($k1) < strlen($k2);
+                return strlen($k1) - strlen($k2);
             }
         );
         $paramNum = 0;

--- a/src/datasources/PostgreSQLDataSource.php
+++ b/src/datasources/PostgreSQLDataSource.php
@@ -203,8 +203,7 @@ class PostgreSQLDataSource extends DataSource
         uksort(
             $sqlParams,
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($sqlParams as $key=>$value) {
@@ -331,8 +330,7 @@ class PostgreSQLDataSource extends DataSource
         uksort(
             $paramNames,
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($paramNames as $i => $k) {

--- a/src/datasources/SQLSRVDataSource.php
+++ b/src/datasources/SQLSRVDataSource.php
@@ -221,8 +221,7 @@ class SQLSRVDataSource extends DataSource
         uksort(
             $sqlParams,
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($sqlParams as $key=>$value) {
@@ -319,8 +318,7 @@ class SQLSRVDataSource extends DataSource
         uksort(
             $paramNames,
             function ($k1, $k2) {
-                if (strlen($k1) == strlen($k2)) return 0;
-                else return strlen($k1) < strlen($k2) ? 1 : -1;
+                return strlen($k1) - strlen($k2);
             }
         );
         foreach ($paramNames as $k) {


### PR DESCRIPTION
* Started out fixing the errors thrown in PHP8 in PdoDataSource.php.
* The rest were OK, but overcomplicated.

The PHP Docs say: "The comparison function must return an integer less than, equal to, or greater than zero if the first argument is considered to be respectively less than, equal to, or greater than the second."

Which means simply Subtracting the strlen() of the second param/key from the strlen() of the first would always provide the relative difference as per the documentation, a number less than, equal to or greater than zero depending on if first argument is less than, equal to or greater than the second.