### PR TITLE
Allow an existing, pre-setup PDO object to be passed as a PdoDataSource

### DIFF
--- a/src/datasources/PdoDataSource.php
+++ b/src/datasources/PdoDataSource.php
@@ -120,7 +120,14 @@ class PdoDataSource extends DataSource
      */
     protected function onInit()
     {
-        // $this->connection = Util::get($this->params,"connection",null);
+        /* If a PDO object is passed, then we should just store that and move on
+         * We should assume it is being reused from somewhere in the calling code,
+         * and is all setup ready to go. */
+        $this->connection = Util::get($this->params,"connection",null);
+        if ($this->connection !== null) {
+            return;
+        }
+
         $connectionString = Util::get($this->params, "connectionString", "");
         $username = Util::get($this->params, "username", "");
         $password = Util::get($this->params, "password", "");


### PR DESCRIPTION
There's a feature that has been commented out for 5 years which I think is valuable and should be allowed. In `src/datasources/PdoDataSource.php`, having the ability to pass in an already pre-configured PDO would be a useful feature to have enabled ([rather than being commented out](https://github.com/koolreport/core/blob/7cf23aabc30b1ab377178dbd2e74d2e92380022f/src/datasources/PdoDataSource.php#L123)).

In my case, I'm using Symfony 6.x and Doctrine ORM in my app, and I'm looking to integrate in KoolReport into that Symfony app. [Doctrine's DBAL allows you to get the underlying PDO](https://github.com/doctrine/dbal/blob/79ea9d6eda8e8e8705f2db58439e9934d8c769da/src/Connection.php#L1645) by:

```
$this->connection->getNativeConnection()
```

This PR allows us to pass this existing PDO object, already setup by the web framework, to KoolReport to use. In doing this, we also get to reuse the database connection Doctrine has from the current request (meaning we don't open another database connection needlessly - useful when your database is licensed per-connection).

With this, the Report class becomes:
```
namespace App\Reports;

use Doctrine\DBAL\Connection;

class ExampleReport extends \koolreport\KoolReport
{
    public function __construct(
        private readonly Connection $connection
    )
    {
        parent::__construct();
    }

    public function settings() : array
    {
        return array(
            "dataSources"=>array(
                "automaker"=>array(
                    "connection" => $this->connection->getNativeConnection()
                )
            )
        );
    }

    public function setup()
    {
       // [...]
    }
}
```

and the Symfony Controller class, which uses autowiring / dependency injection to pass in the `$connection`:
```
namespace App\Controller;

use Doctrine\DBAL\Connection;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\Routing\Annotation\Route;

class ReportExampleController extends AbstractController
{
    public function __construct(
        private readonly Connection $connection
    ) 
    {}

    #[Route(path: '/report-example', name: 'report_example', methods: ['GET'])]
    public function reportExample(Request $request): Response
    {
        $report = new \App\Reports\ExampleReport($this->connection);
        return $this->render('report_example.html.twig', [
            'report' => $report->run()->render(true),
            'report_name' => "Example report"
        ]);
    }
}
```

The ability to send down the existing PDO object in this (common) circumstance will avoid errors in re-parsing Doctrine `DATABASE_URL` strings into PDO connection strings, and holding two database connections open when one will do fine.